### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Compagnie-Hydromel/CompagnieHydromel/security/code-scanning/1](https://github.com/Compagnie-Hydromel/CompagnieHydromel/security/code-scanning/1)

In general, this problem is fixed by explicitly setting a `permissions` block either at the workflow root (to apply to all jobs) or within each job (for per-job control). The permissions should follow least privilege: in this case, the workflow only needs to read the repository contents to run tests and format checks, so `contents: read` is sufficient.

The single best fix here, without changing functionality, is to add a `permissions` block at the top level of `.github/workflows/ci.yml`, directly under the `name: CI` (or after `on:` if preferred, but staying minimal). This block will apply to the `ci` job because it does not define its own permissions. The new block should look like:

```yaml
permissions:
  contents: read
```

Concretely, in `.github/workflows/ci.yml`, add these lines between line 2 (the blank line after `name: CI`) and line 3 (`on:`). No additional imports or definitions are required; GitHub Actions will interpret the `permissions` block natively. This change limits the `GITHUB_TOKEN` for the workflow to read-only access to repository contents while preserving all existing behavior of the CI steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
